### PR TITLE
Sparse rate matrix

### DIFF
--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -56,28 +56,21 @@ def sparse_rate_matrix(M, s):
             return True
         return False
 
-    iupper = [] 
-    iupper_const = []
+    iupper = [[] for i in range(M)]
+    iupper_const = [[] for i in range(M)]
+    
     for i, a1 in enumerate(tuples):
         for j, a2 in enumerate(tuples):
             if i < j:
                 if mutation(a1, a2):
-                    iupper.append([0, i, j])
+                    for m in range(M):
+                        iupper[m].append([m, i, j])
                 else:
-                    iupper_const.append([0, i, j])
+                    for m in range(M):
+                        iupper_const[m].append([m, i, j])    
 
-    iupperM = [iupper]
-    iupperM_const = [iupper_const]
-    for m in range(1, M):
-        for i in range(len(iupper)):
-            iupper[i][0] = m
-        for j in range(len(iupper_const)):
-            iupper_const[j][0] = m        
-        iupperM.append(iupper)
-        iupperM_const.append(iupper_const)
-
-    iupperM = tf.convert_to_tensor(iupperM, dtype=tf.int64)
-    iupperM_const = tf.convert_to_tensor(iupperM_const, dtype=tf.int64)
+    iupperM = tf.convert_to_tensor(iupper, dtype=tf.int64)
+    iupperM_const = tf.convert_to_tensor(iupper_const, dtype=tf.int64)
     return iupperM, iupperM_const
 
 @tf.function

--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -97,7 +97,7 @@ def generator(rates, stationairy_distribution, should_normalize_expected_mutatio
         iupper = tensor_utils.broadcast_matrix_indices_to_tensor_indices(mat_ind, (M, s, s)).reshape((M, -1, 3))
         iupper = tf.convert_to_tensor(iupper)
     else:
-        const_rates = 0.01/(s*s)
+        const_rates = 0.01/(s-1)
         iupper, iupper_const = sparse_rate_matrix(M, s)
         rates_const = tf.convert_to_tensor(np.zeros((M, int(s * (s - 1) / 2 - rates.shape[-1]))) + const_rates)
 

--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -17,62 +17,6 @@ def inv_stereographic_projection(y):
         x = tf.concat([2 * y, (norm_square - 1)[...,None]], axis = -1) * (1 / (norm_square + 1))[...,None]
         return x
 
-@tf.function 
-def sparse_rate_matrix(M, s):
-    """
-    Returns indices for the upper triangle rate matrix. Allowed are only transitions with maximal one mutation.
-
-    Args:
-        M (int): Number of models
-        s (int): size of the alphabet
-
-    Returns:
-        tf.Tensor: Tensor with all indices of the trainable parameter for the rate matrix construction
-        tf.Tensor: Tensor with all indices that are not trainable parameter for the rate matrix construction
-    """
-
-    max_tuple_length = 10
-    nuc_alphabet_s = [4 ** i for i in range(2, max_tuple_length)]
-    amino_alphabet_s = [20 ** i for i in range(2, max_tuple_length)]
-    
-    if s in nuc_alphabet_s:
-        tuple_length = nuc_alphabet_s.index(s) + 2
-        alphabet = "acgt"
-    elif s in amino_alphabet_s:
-        tuple_length = amino_alphabet_s.index(s) + 2
-        alphabet = "ARNDCEQGHILKMFPSTWYV"
-    else:
-        raise ValueError(f"Unknown alphabet size: {s}. Supported are: {nuc_alphabet_s} for nucleotides and {amino_alphabet_s} for amino acids. The tuple length must be bigger than 1.")
-
-    tuples = itertools.product(*[alphabet for i in range(tuple_length)])
-    tuples = [''.join(c) for c in tuples]    
-
-    def mutation(a1, a2, max_allowed_mutations = 1):
-        mutations_found = 0
-        for i in range(len(a1)):
-            if a1[i] != a2[i]:
-                mutations_found += 1
-        if mutations_found <= max_allowed_mutations:
-            return True
-        return False
-
-    iupper = [[] for i in range(M)]
-    iupper_const = [[] for i in range(M)]
-    
-    for i, a1 in enumerate(tuples):
-        for j, a2 in enumerate(tuples):
-            if i < j:
-                if mutation(a1, a2):
-                    for m in range(M):
-                        iupper[m].append([m, i, j])
-                else:
-                    for m in range(M):
-                        iupper_const[m].append([m, i, j])    
-
-    iupperM = tf.convert_to_tensor(iupper, dtype=tf.int64)
-    iupperM_const = tf.convert_to_tensor(iupper_const, dtype=tf.int64)
-    return iupperM, iupperM_const
-
 @tf.function
 def generator(rates, stationairy_distribution, should_normalize_expected_mutations=False, sparse_rates = False):
     """ construct matrices from the rates, pi"""
@@ -89,7 +33,7 @@ def generator(rates, stationairy_distribution, should_normalize_expected_mutatio
         iupper = tf.convert_to_tensor(iupper)
     else:
         const_rates = 0.01 / (s - 1)
-        iupper, iupper_const = sparse_rate_matrix(M, s)
+        iupper, iupper_const = tensor_utils.sparse_rate_matrix(M, s)
         rates_const = tf.convert_to_tensor(np.zeros((M, int(s * (s - 1) / 2 - rates.shape[-1]))) + const_rates)
 
     rates = rates 

--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -27,8 +27,8 @@ def sparse_rate_matrix(M, s):
         s (int): size of the alphabet
 
     Returns:
-        tf.Tensor: Tensor with all indices of the parameter for the rate matrix construction
-        tf.Tensor: Tensor with all indices that are not parameter for the rate matrix construction
+        tf.Tensor: Tensor with all indices of the trainable parameter for the rate matrix construction
+        tf.Tensor: Tensor with all indices that are not trainable parameter for the rate matrix construction
     """
 
     max_tuple_length = 10
@@ -89,15 +89,13 @@ def generator(rates, stationairy_distribution, should_normalize_expected_mutatio
 
     pi = stationairy_distribution
 
-    # Retrieve the row and column indices for
-    # triangle matrix above the diagonal
-
-    if not sparse_rates:
+    if not sparse_rates:  
+        # Retrieve the row and column indices for triangle matrix above the diagonal
         mat_ind = np.stack(np.triu_indices(s, 1), axis = -1)
         iupper = tensor_utils.broadcast_matrix_indices_to_tensor_indices(mat_ind, (M, s, s)).reshape((M, -1, 3))
         iupper = tf.convert_to_tensor(iupper)
     else:
-        const_rates = 0.01/(s-1)
+        const_rates = 0.01 / (s - 1)
         iupper, iupper_const = sparse_rate_matrix(M, s)
         rates_const = tf.convert_to_tensor(np.zeros((M, int(s * (s - 1) / 2 - rates.shape[-1]))) + const_rates)
 

--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -32,8 +32,8 @@ def sparse_rate_matrix(M, s):
     """
 
     max_tuple_length = 10
-    nuc_alphabet_s = [4 ** i for i in range(1, max_tuple_length)]
-    amino_alphabet_s = [20 ** i for i in range(1, max_tuple_length)]
+    nuc_alphabet_s = [4 ** i for i in range(2, max_tuple_length)]
+    amino_alphabet_s = [20 ** i for i in range(2, max_tuple_length)]
     
     if s in nuc_alphabet_s:
         tuple_length = nuc_alphabet_s.index(s) + 1
@@ -107,7 +107,7 @@ def generator(rates, stationairy_distribution, should_normalize_expected_mutatio
         if sparse_rates:    
             # tcmc does not allow rates of size 0, leads to error while training
             Q_const = tf.scatter_nd(iupper_const, rates_const, shape=(M, s, s), name = "const_rate_matrix")
-            Q += Q_const
+            Q = Q + Q_const
     with tf.name_scope("symmetrize"):
         Q = Q + tf.transpose(Q,(0, 2, 1), name = "transpose")
     with tf.name_scope("apply_stationary_probabilites"):

--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -42,7 +42,7 @@ def sparse_rate_matrix(M, s):
         tuple_length = amino_alphabet_s.index(s) + 1
         alphabet = "ARNDCEQGHILKMFPSTWYV"
     else:
-        raise ValueError(f"Unknown alphabet size: {s}. Supported are: {nuc_alphabet_s + amino_alphabet_s}.")
+        raise ValueError(f"Unknown alphabet size: {s}. Supported are: {nuc_alphabet_s} for nucleotides and {amino_alphabet_s} for amino acids. The tuple length must be bigger than 1.")
 
     tuples = itertools.product(*[alphabet for i in range(tuple_length)])
     tuples = [''.join(c) for c in tuples]    
@@ -97,7 +97,7 @@ def generator(rates, stationairy_distribution, should_normalize_expected_mutatio
         iupper = tensor_utils.broadcast_matrix_indices_to_tensor_indices(mat_ind, (M, s, s)).reshape((M, -1, 3))
         iupper = tf.convert_to_tensor(iupper)
     else:
-        const_rates = 0.00001
+        const_rates = 0.01/(s*s)
         iupper, iupper_const = sparse_rate_matrix(M, s)
         rates_const = tf.convert_to_tensor(np.zeros((M, int(s * (s - 1) / 2 - rates.shape[-1]))) + const_rates)
 

--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -36,10 +36,10 @@ def sparse_rate_matrix(M, s):
     amino_alphabet_s = [20 ** i for i in range(2, max_tuple_length)]
     
     if s in nuc_alphabet_s:
-        tuple_length = nuc_alphabet_s.index(s) + 1
+        tuple_length = nuc_alphabet_s.index(s) + 2
         alphabet = "acgt"
     elif s in amino_alphabet_s:
-        tuple_length = amino_alphabet_s.index(s) + 1
+        tuple_length = amino_alphabet_s.index(s) + 2
         alphabet = "ARNDCEQGHILKMFPSTWYV"
     else:
         raise ValueError(f"Unknown alphabet size: {s}. Supported are: {nuc_alphabet_s} for nucleotides and {amino_alphabet_s} for amino acids. The tuple length must be bigger than 1.")

--- a/tcmc/math.py
+++ b/tcmc/math.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 import numpy as np
 from . import tensor_utils
-import itertools
 
 @tf.function
 def stereographic_projection(x):

--- a/tcmc/nwk_utils.py
+++ b/tcmc/nwk_utils.py
@@ -46,36 +46,34 @@ def nwk_reads(nwk_string, return_variable_configuration=True):
 
     print ("Read tree with node names", names,
            ". Thereof leaves", leave_names)
-    
+
     # get a buttom up order of the nodes
     V = [nodes[names.index(l)] for l in leave_names]
     n = len(nodes)
     k = len(leave_names)
-    
+
     for it in list(range(k)) + list(reversed(range(k,n))):
         v = V[it]
         w = v
-        
+
         while w != None:
-        
-            
+
             # add parent to nodes if note present
             if w not in V:
                 V.append(w)
-            
+
             # start repairing indicies by a bubble sort like algorithm
             elif V.index(v) > V.index(w):
                 i = V.index(v)
                 j = V.index(w)
                 V[i] = w
                 V[j] = v
-            
+
             v = w
             w = w.ancestor
-            
-    
+
     E = sorted([(V.index(nodes[v]), V.index(nodes[w])) for (v,w) in edges])
-    
+
     if return_variable_configuration:
         # calculate the needed variables and dependencies for edge lengths
         T = np.zeros((len(E), len(E)))

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -128,12 +128,11 @@ class TCMCProbability(tf.keras.layers.Layer):
                 t = amino_s.index(s) + 1
                 u = 20
             if t == 1:
-                raise ValueError("The tuple_length must be bigger than 1.")
+                raise ValueError("The tuple_length must be bigger than 1 if you want to use a sparse rate matrix.")
 
             self.R_inv = self.add_weight(shape = (M, int((u-1)*t*s/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)
             
-
         # we use the inverse of stereographic projection to get a probability vector
         #kernel_init = tf.initializers.constant(1.0 / (np.sqrt(s) - 1)) # this initializes pi with uniform distribution
         self.pi_inv = self.add_weight(shape=(M, s-1), name = "pi_inv", dtype = tf.float64,

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -29,18 +29,18 @@ class TCMCProbability(tf.keras.layers.Layer):
         self.stationary_distribution_initializer = tf.keras.initializers.get(stationary_distribution_initializer)
         self.rates_initializer = tf.keras.initializers.get(rates_initializer)
         self.generator_regularizer = tf.keras.regularizers.get(generator_regularizer)
-        self.sparse_rates = False 
+        self.sparse_rates = sparse_rates 
     
 
     def __init__(self,
                  model_shape,
                  forest,
-                 sparse_rates=False,
                  should_train_lengths=False,
                  stationary_distribution_initializer=None,
                  rates_initializer=None,
                  generator_regularizer=None,
-                 activity_regularizer=None,
+                 activity_regularizer=None,                 
+                 sparse_rates=False,
                  **kwargs):
         
         if not 'dtype' in kwargs:

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -127,7 +127,7 @@ class TCMCProbability(tf.keras.layers.Layer):
             elif s in amino_s:
                 t = amino_s.index(s) + 1
                 u = 20
-            self.R_inv = self.add_weight(shape = (M, int((u-1)*t*(u**t)/2), name = "R_inv", dtype = tf.float64,
+            self.R_inv = self.add_weight(shape = (M, int((u-1)*t*(u**t)/2)), name = "R_inv", dtype = tf.float64,
                                      initializer = rates_initializer)
             
 

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -116,19 +116,19 @@ class TCMCProbability(tf.keras.layers.Layer):
         if not self.sparse_rates:
             # The parameters that we want to learn
             self.R_inv = self.add_weight(shape = (M, int(s*(s-1)/2)), name = "R_inv", dtype = tf.float64,
-                                     initializer = rates_initializer)
+                                         initializer = rates_initializer)
         else:
             max_tuple_length = 10
-            nuc_s = [4 ** i for i in range(1, max_tuple_length)]
-            amino_s = [20 ** i for i in range(1, max_tuple_length)]
+            nuc_s = [4 ** i for i in range(2, max_tuple_length)]
+            amino_s = [20 ** i for i in range(2, max_tuple_length)]
             if s in nuc_s:
-                t = nuc_s.index(s) + 1
+                t = nuc_s.index(s) + 2
                 u = 4
             elif s in amino_s:
-                t = amino_s.index(s) + 1
+                t = amino_s.index(s) + 2
                 u = 20
-            self.R_inv = self.add_weight(shape = (M, int((u-1)*t*(u**t)/2)), name = "R_inv", dtype = tf.float64,
-                                     initializer = rates_initializer)
+            self.R_inv = self.add_weight(shape = (M, int((u-1)*t*s/2)), name = "R_inv", dtype = tf.float64,
+                                         initializer = rates_initializer)
             
 
         # we use the inverse of stereographic projection to get a probability vector

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -118,8 +118,6 @@ class TCMCProbability(tf.keras.layers.Layer):
             self.R_inv = self.add_weight(shape = (M, int(s*(s-1)/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)
         else:
-
-            
             max_tuple_length = 10
             nuc_s = [4 ** i for i in range(1, max_tuple_length)]
             amino_s = [20 ** i for i in range(1, max_tuple_length)]

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -130,8 +130,8 @@ class TCMCProbability(tf.keras.layers.Layer):
                 tuple_length = amino_s.index(s) + min_tuple_length
                 u = 20
             else:
-                raise ValueError(f"Currently we support dna (4) and amino acids (20) alphabets only. This means, that your input\
- alphabet size s (s={s}) must be 4**t (dna) or 20**t (amino acids) for tuple length t with {max_tuple_length} >= t >= {min_tuple_length}.")
+                raise ValueError(f"Currently we support dna (4) and amino acids (20) alphabets only for the sparse rates parameter. This means, that\
+ your input alphabet size s (s={s}) must be 4**t (dna) or 20**t (amino acids) for tuple length t with {max_tuple_length} >= t >= {min_tuple_length}.")
 
             self.R_inv = self.add_weight(shape = (M, int((u-1)*tuple_length*s/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -130,9 +130,8 @@ class TCMCProbability(tf.keras.layers.Layer):
                 tuple_length = amino_s.index(s) + min_tuple_length
                 u = 20
             else:
-                raise ValueError(f"Currently we support dna (4) and amino acids (20) alphabets only.\
-This means, that your input alphabet size s must be 4**t (dna) or 20**t (amino acids)\
- for tuple length t with {max_tuple_length} >= t >= {min_tuple_length}.")
+                raise ValueError(f"Currently we support dna (4) and amino acids (20) alphabets only. This means, that your input\
+ alphabet size s (s={s}) must be 4**t (dna) or 20**t (amino acids) for tuple length t with {max_tuple_length} >= t >= {min_tuple_length}.")
 
             self.R_inv = self.add_weight(shape = (M, int((u-1)*tuple_length*s/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -118,19 +118,21 @@ class TCMCProbability(tf.keras.layers.Layer):
             self.R_inv = self.add_weight(shape = (M, int(s*(s-1)/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)
         else:
+            # currently for dna (4) and amino acids (20) alphabets only
             max_tuple_length = 10
-            nuc_s = [4 ** i for i in range(1, max_tuple_length)]
-            amino_s = [20 ** i for i in range(1, max_tuple_length)]
+            min_tuple_length = 2
+            nuc_s = [4 ** i for i in range(min_tuple_length, max_tuple_length)]
+            amino_s = [20 ** i for i in range(min_tuple_length, max_tuple_length)]
             if s in nuc_s:
-                t = nuc_s.index(s) + 1
+                tuple_length = nuc_s.index(s) + min_tuple_length
                 u = 4
             elif s in amino_s:
-                t = amino_s.index(s) + 1
+                tuple_length = amino_s.index(s) + min_tuple_length
                 u = 20
-            if t == 1:
-                raise ValueError("The tuple_length must be bigger than 1 if you want to use a sparse rate matrix.")
+            else:
+                raise ValueError(f"Currently we support dna (4) and amino acids (20) alphabets only. This means, that your input alphabet size s must be 4**t (dna) or 20**t (amino acids) for tuple length t with 10 >= t >= 2.")
 
-            self.R_inv = self.add_weight(shape = (M, int((u-1)*t*s/2)), name = "R_inv", dtype = tf.float64,
+            self.R_inv = self.add_weight(shape = (M, int((u-1)*tuple_length*s/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)
             
         # we use the inverse of stereographic projection to get a probability vector

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -130,7 +130,9 @@ class TCMCProbability(tf.keras.layers.Layer):
                 tuple_length = amino_s.index(s) + min_tuple_length
                 u = 20
             else:
-                raise ValueError(f"Currently we support dna (4) and amino acids (20) alphabets only. This means, that your input alphabet size s must be 4**t (dna) or 20**t (amino acids) for tuple length t with 10 >= t >= 2.")
+                raise ValueError(f"Currently we support dna (4) and amino acids (20) alphabets only.\
+This means, that your input alphabet size s must be 4**t (dna) or 20**t (amino acids)\
+ for tuple length t with {max_tuple_length} >= t >= {min_tuple_length}.")
 
             self.R_inv = self.add_weight(shape = (M, int((u-1)*tuple_length*s/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)

--- a/tcmc/tcmc.py
+++ b/tcmc/tcmc.py
@@ -118,15 +118,20 @@ class TCMCProbability(tf.keras.layers.Layer):
             self.R_inv = self.add_weight(shape = (M, int(s*(s-1)/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)
         else:
+
+            
             max_tuple_length = 10
-            nuc_s = [4 ** i for i in range(2, max_tuple_length)]
-            amino_s = [20 ** i for i in range(2, max_tuple_length)]
+            nuc_s = [4 ** i for i in range(1, max_tuple_length)]
+            amino_s = [20 ** i for i in range(1, max_tuple_length)]
             if s in nuc_s:
-                t = nuc_s.index(s) + 2
+                t = nuc_s.index(s) + 1
                 u = 4
             elif s in amino_s:
-                t = amino_s.index(s) + 2
+                t = amino_s.index(s) + 1
                 u = 20
+            if t == 1:
+                raise ValueError("The tuple_length must be bigger than 1.")
+
             self.R_inv = self.add_weight(shape = (M, int((u-1)*t*s/2)), name = "R_inv", dtype = tf.float64,
                                          initializer = rates_initializer)
             

--- a/tcmc/tensor_utils.py
+++ b/tcmc/tensor_utils.py
@@ -123,7 +123,7 @@ def batched_segment_indices(segment_lengths):
 
 def sparse_rate_matrix(M, s):
     """
-    Returns indices for the upper triangle rate matrix. Allowed are only transitions with maximal one mutation.
+    Returns indices for the upper triangle rate matrix. Allowed are only transitions with at most one mutation per tuple.
 
     Args:
         M (int): Number of models
@@ -135,14 +135,15 @@ def sparse_rate_matrix(M, s):
     """
 
     max_tuple_length = 10
-    nuc_alphabet_s = [4 ** i for i in range(2, max_tuple_length)]
-    amino_alphabet_s = [20 ** i for i in range(2, max_tuple_length)]
+    min_tuple_length = 2
+    nuc_alphabet_s = [4 ** i for i in range(min_tuple_length, max_tuple_length)]
+    amino_alphabet_s = [20 ** i for i in range(min_tuple_length, max_tuple_length)]
     
     if s in nuc_alphabet_s:
-        tuple_length = nuc_alphabet_s.index(s) + 2
+        tuple_length = nuc_alphabet_s.index(s) + min_tuple_length
         alphabet = "acgt"
     elif s in amino_alphabet_s:
-        tuple_length = amino_alphabet_s.index(s) + 2
+        tuple_length = amino_alphabet_s.index(s) + min_tuple_length
         alphabet = "ARNDCEQGHILKMFPSTWYV"
     else:
         raise ValueError(f"Unknown alphabet size: {s}. Supported are: {nuc_alphabet_s} for nucleotides and {amino_alphabet_s} for amino acids. The tuple length must be bigger than 1.")

--- a/tcmc/tensor_utils.py
+++ b/tcmc/tensor_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+import itertools
 
 def crosscat_matrices(A,B):
     """Concat the rows matrices A,B in a crossproducty way.


### PR DESCRIPTION
- implemented a sparse rate matrix
- let s = u**t the alphabet size with tuple length t and input alphabet size u (e.g. u=20 for amino acids) than the sparse rate matrix has only (u-1) * t * s/2 parameters instead of (s-1)*s/2
- works for amino acids and nucleotides